### PR TITLE
fix bug in notify function because I didn't await client.send() promise

### DIFF
--- a/src/lib/car.js
+++ b/src/lib/car.js
@@ -134,7 +134,8 @@ async function storeCar({ id, skipExists, logger }) {
       // @todo - consider including duration as nanoseconds instead of startTime/endTime milliseconds-resolution Dates
       startTime: new Date(Number(start) / 1e6),
       endTime: new Date()
-    }
+    },
+    logger
   })
 }
 

--- a/src/lib/publish.js
+++ b/src/lib/publish.js
@@ -54,10 +54,11 @@ async function publishBatch({ queue, messages, logger }) {
 async function notify({ client = snsClient, message, topic, logger }) {
   telemetry.increaseCount('sns-publishes')
   const send = async () => {
-    client.send(new PublishCommand({
+    const response = await client.send(new PublishCommand({
       Message: message,
       TopicArn: topic
     }))
+    logger.info(`sent sns message on topic=${topic} response=${response}`)
   }
   try {
     await telemetry.trackDuration('sns-publishes', send())

--- a/test/lib-publish.test.js
+++ b/test/lib-publish.test.js
@@ -5,6 +5,7 @@ const { SendMessageCommand, SendMessageBatchCommand } = require('@aws-sdk/client
 const { serializeError } = require('../src/lib/logging')
 const { publish, publishBatch, notify } = require('../src/lib/publish')
 const { sqsMock } = require('./utils/mock')
+const { logger: defaultLogger } = require('../src/lib/logging')
 
 t.test('publish', async t => {
   t.test('should call SQSClient with "SendMessageCommand"', async t => {
@@ -84,7 +85,7 @@ t.test('notify', async t => {
         return Promise.resolve()
       }
     }
-    await notify({ client: fakeClient, message, topic })
+    await notify({ client: fakeClient, message, topic, logger: defaultLogger })
     t.equal(sentCommands.length, 1)
     const [command] = sentCommands
     t.equal(command.input.Message, message)


### PR DESCRIPTION
Motivation
* When debugging deployment of https://github.com/elastic-ipfs/indexer-lambda/pull/59 , we noticed that no messages were going into the events queue. This is probably because I forgot to `await` the promise here. We also add an `info` log so we can be sure things worked based on the lambda logs