### PR TITLE
fix bug with wrong IndexerCompleted#indexing.startTime

### DIFF
--- a/src/lib/car.js
+++ b/src/lib/car.js
@@ -89,6 +89,7 @@ async function notifyIndexerCompletedEvent({
 
 async function storeCar({ id, skipExists, logger }) {
   const start = process.hrtime.bigint()
+  const startDate = new Date()
 
   const car = validateCar(id)
   if (!car) {
@@ -127,7 +128,7 @@ async function storeCar({ id, skipExists, logger }) {
     },
     indexing: {
       // @todo - consider including duration as nanoseconds instead of startTime/endTime milliseconds-resolution Dates
-      startTime: new Date(Number(start) / 1e6),
+      startTime: startDate,
       endTime: new Date()
     },
     logger

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -82,7 +82,9 @@ function assertIsIndexerCompletedPublish(t, snsPublish) {
   assertIsIndexerCompletedEvent(t, event)
 }
 
-function assertIsIndexerCompletedEvent(t, event) {
+const ONE_HOUR_MILLISECONDS = 1000 * 60 * 60
+
+function assertIsIndexerCompletedEvent(t, event, maxDurationMs = ONE_HOUR_MILLISECONDS) {
   t.equal(event.type, 'IndexerCompleted', 'event has type IndexerCompleted')
   t.ok(event.indexing, 'event has .indexing')
   for (const property of ['startTime', 'endTime']) {
@@ -92,5 +94,6 @@ function assertIsIndexerCompletedEvent(t, event) {
   if (event.indexing.startTime && event.indexing.endTime) {
     const toDate = (dateString) => new Date(Date.parse(dateString))
     t.equal(toDate(event.indexing.startTime) < toDate(event.indexing.endTime), true, 'startTime is before endTime')
+    t.equal(toDate(event.indexing.endTime) - toDate(event.indexing.startTime) < maxDurationMs, true, 'endTime-startTime difference should be less than maxDurationMs')
   }
 }


### PR DESCRIPTION
Motivation
* fix bug https://github.com/elastic-ipfs/indexer-lambda/issues/63

Context
* It feels suboptimal/lossy to be passing `indexing.{startTime, endTime}` as ISO8601 strings, and then calculating the duration from that in metrics-collector.
  * I think we should switch to providing the duration explicitly, including Nanoseconds values (JSON + ISO8601 strings can't do that) https://github.com/elastic-ipfs/metrics-collector/issues/33
  * but I pulled that out of this PR and into a followup so this one is simply a fix to the `startTime` bug