### PR TITLE
emitted IndexerCompleted#indexing.duration is set

### DIFF
--- a/src/lib/car.js
+++ b/src/lib/car.js
@@ -7,6 +7,7 @@ const { createDynamoItem, readDynamoItem } = require('./storage')
 const { notify } = require('./publish')
 const { now } = require('./util')
 const { storeBlocks, publishBlocks } = require('./block')
+const { Nanoseconds } = require('./time')
 
 function validateCar(id) {
   try {
@@ -63,6 +64,7 @@ async function createCar({ car, source, logger }) {
  * @param {URL} options.car.contentLength - byte length of CAR file
  * @param {object} options.indexing - describes the indexing process
  * @param {Date} options.indexing.startTime - when indexing began
+ * @param {Nanoseconds} options.indexing.duration - duration of indexing
  * @param {Date} options.indexing.endTime - when indexing completed
  * @param {Logger} options.logger - used to log errors
  */
@@ -80,6 +82,7 @@ async function notifyIndexerCompletedEvent({
       uri: car.url.toString(),
       byteLength: car.contentLength,
       indexing: {
+        duration: indexing.duration,
         startTime: indexing.startTime.toISOString(),
         endTime: indexing.endTime.toISOString()
       }
@@ -126,14 +129,16 @@ async function storeCar({ id, skipExists, logger }) {
       contentLength: source.stats.contentLength
     },
     indexing: {
-      // @todo - consider including duration as nanoseconds instead of startTime/endTime milliseconds-resolution Dates
       startTime: new Date(Number(start) / 1e6),
-      endTime: new Date()
+      endTime: new Date(),
+      // https://schema.org/duration
+      duration: new Nanoseconds(process.hrtime.bigint() - start)
     },
     logger
   })
 }
 
 module.exports = {
+  Nanoseconds,
   storeCar
 }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -1,0 +1,39 @@
+// https://unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex3e.pdf
+const NANOSECONDS_UNECE_UNIT_CODE = 'C47'
+
+/**
+ * @typedef JsonNanoseconds
+ * @property {'C47'} unitCode - https://schema.org/unitCode https://unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex3e.pdf
+ * @property {string} value
+ */
+
+class Nanoseconds {
+  /**
+     * @param {bigint} value
+     */
+  constructor(value) {
+    this.value = value
+  }
+
+  /**
+     * @returns {JsonNanoseconds}
+     */
+  toJSON() {
+    return {
+      unitCode: NANOSECONDS_UNECE_UNIT_CODE,
+      value: this.value.toString()
+    }
+  }
+
+  /**
+     * @param {JsonNanoseconds} arg
+     */
+  static fromJSON(arg) {
+    return new Nanoseconds(BigInt(arg.value))
+  }
+}
+
+module.exports = {
+  Nanoseconds,
+  NANOSECONDS_UNECE_UNIT_CODE
+}

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -9,15 +9,15 @@ const NANOSECONDS_UNECE_UNIT_CODE = 'C47'
 
 class Nanoseconds {
   /**
-     * @param {bigint} value
-     */
+   * @param {bigint} value
+   */
   constructor(value) {
     this.value = value
   }
 
   /**
-     * @returns {JsonNanoseconds}
-     */
+   * @returns {JsonNanoseconds}
+   */
   toJSON() {
     return {
       unitCode: NANOSECONDS_UNECE_UNIT_CODE,
@@ -26,8 +26,9 @@ class Nanoseconds {
   }
 
   /**
-     * @param {JsonNanoseconds} arg
-     */
+   * @param {JsonNanoseconds} arg
+   * @returns {Nanoseconds}
+   */
   static fromJSON(arg) {
     return new Nanoseconds(BigInt(arg.value))
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,8 +3,7 @@
 const t = require('tap')
 const config = require('../src/config')
 const { handler } = require('../src/index')
-const { Nanoseconds } = require('../src/lib/car')
-const { NANOSECONDS_UNECE_UNIT_CODE } = require('../src/lib/time')
+const { Nanoseconds, NANOSECONDS_UNECE_UNIT_CODE } = require('../src/lib/time')
 const helper = require('./utils/helpers')
 const { mockDynamoGetItemCommand, mockS3GetObject, trackDynamoUsages, trackSQSUsages, readMockJSON, readMockData, trackSNSUsages } = require('./utils/mock')
 
@@ -96,10 +95,10 @@ function assertIsIndexerCompletedEvent(t, event, maxDurationMs = ONE_HOUR_MILLIS
   if (event.indexing.startTime && event.indexing.endTime) {
     const toDate = (dateString) => new Date(Date.parse(dateString))
     t.equal(toDate(event.indexing.startTime) < toDate(event.indexing.endTime), true, 'startTime is before endTime')
+    t.equal(toDate(event.indexing.endTime) - toDate(event.indexing.startTime) < maxDurationMs, true, 'endTime-startTime difference should be less than maxDurationMs')
   }
   t.equal(event.indexing.duration.unitCode, NANOSECONDS_UNECE_UNIT_CODE, 'indexing duration unitCode indicates nanoseconds')
   t.equal(typeof event.indexing.duration.value, 'string', 'indexing duration value is a string')
-  t.equal(Nanoseconds.fromJSON(event.indexing.duration) instanceof Nanoseconds, true, 'indexing duration can be converted to Nanoseconds')
-  t.equal(event.indexing.duration.value > 0, true, 'indexing duration is greater than zero')
-  t.equal(toDate(event.indexing.endTime) - toDate(event.indexing.startTime) < maxDurationMs, true, 'endTime-startTime difference should be less than maxDurationMs')
+  const indexingDuration = Nanoseconds.fromJSON(event.indexing.duration)
+  t.equal(indexingDuration.value > BigInt(0), true, 'indexing duration is greater than zero')
 }


### PR DESCRIPTION
Motivation
* https://github.com/elastic-ipfs/metrics-collector/issues/33
  * note how deploying this PR is an early step of changes (here https://github.com/elastic-ipfs/metrics-collector/issues/33#issuecomment-1209995302) that can correspond to making use of this more accurate `duration` inside metrics-collector. Only once we deploy that can I add another PR here to remove the ISO8601 startTime/endTime from `indexing` prop