### PR TITLE
fix: stop writing to blocks v1 table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ _Variables in bold are required._
 | --------------------------- | ------------------ | ------------------------------------------------------------------------------ |
 | CONCURRENCY                 | `32`               | Concurrent batch inserts of blocks.                                            |
 | BLOCKS_BATCH_SIZE           | `10`               | Batch size for blocks ops (insert, publish). 10 is max for SQS, 25 is max for Dynamo |
-| DYNAMO_BLOCKS_TABLE         | `v1-blocks`        | The DynamoDB table where store CIDs informations to.                           |
 | DYNAMO_CARS_TABLE           | `v1-cars`          | The DynamoDB table where store CAR files informations to.                      |
 | DYNAMO_LINK_TABLE           | `v1-blocks-cars-position`   | The DynamoDB table with CARs-blocks links.                                     |
 | DYNAMO_MAX_RETRIES          | `3`                | DynamoDB max attempts in case of query failure.                                |

--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,6 @@ require('dotenv').config({ path: process.env.ENV_FILE_PATH || resolve(process.cw
 const {
   CONCURRENCY: rawConcurrency,
 
-  DYNAMO_BLOCKS_TABLE: blocksTable,
   DYNAMO_CARS_TABLE: carsTable,
   DYNAMO_LINK_TABLE: linkTable,
 
@@ -49,11 +48,9 @@ const concurrency = parseInt(rawConcurrency)
 
 module.exports = {
   RAW_BLOCK_CODEC,
-  blocksTable: blocksTable ?? 'v1-blocks',
   carsTable: carsTable ?? 'v1-cars',
   linkTable: linkTable ?? 'v1-blocks-cars-position',
 
-  blocksTablePrimaryKey: 'multihash',
   carsTablePrimaryKey: 'path',
   linkTableBlockKey: 'blockmultihash',
   linkTableCarKey: 'carpath',

--- a/tap-snapshots/test/index.test.js.test.cjs
+++ b/tap-snapshots/test/index.test.js.test.cjs
@@ -11,68 +11,6 @@ Object {
     "batchCreates": Array [
       Object {
         "RequestItems": Object {
-          "v1-blocks": Array [
-            Object {
-              "PutRequest": Object {
-                "Item": Object {
-                  "createdAt": Object {
-                    "S": "2022-06-24T15:15:17.401Z",
-                  },
-                  "multihash": Object {
-                    "S": "zQmY13QWtykrcwmQmLVdxAQnJsRq7xBs5FAqH5zpG9ZvJpC",
-                  },
-                  "type": Object {
-                    "S": "raw",
-                  },
-                },
-              },
-            },
-            Object {
-              "PutRequest": Object {
-                "Item": Object {
-                  "createdAt": Object {
-                    "S": "2022-06-24T15:15:17.401Z",
-                  },
-                  "multihash": Object {
-                    "S": "zQmSGtsqx7aYH8gP21AgidxXuX5vsseFJgHKa75kg8HepXL",
-                  },
-                  "type": Object {
-                    "S": "dag-pb",
-                  },
-                },
-              },
-            },
-            Object {
-              "PutRequest": Object {
-                "Item": Object {
-                  "createdAt": Object {
-                    "S": "2022-06-24T15:15:17.401Z",
-                  },
-                  "multihash": Object {
-                    "S": "zQmSHc8o3PxQgMccYgGtuStaNQKXTBX1rTHN5W9cUCwrcHX",
-                  },
-                  "type": Object {
-                    "S": "dag-pb",
-                  },
-                },
-              },
-            },
-            Object {
-              "PutRequest": Object {
-                "Item": Object {
-                  "createdAt": Object {
-                    "S": "2022-06-24T15:15:17.401Z",
-                  },
-                  "multihash": Object {
-                    "S": "zQmTgGQZ3ZcbcHxZiFNHs76Y7Ca8DfFGjdsxXDVnr41h339",
-                  },
-                  "type": Object {
-                    "S": "dag-pb",
-                  },
-                },
-              },
-            },
-          ],
           "v1-blocks-cars-position": Array [
             Object {
               "PutRequest": Object {
@@ -151,23 +89,6 @@ Object {
       },
       Object {
         "RequestItems": Object {
-          "v1-blocks": Array [
-            Object {
-              "PutRequest": Object {
-                "Item": Object {
-                  "createdAt": Object {
-                    "S": "2022-06-24T15:15:17.401Z",
-                  },
-                  "multihash": Object {
-                    "S": "zQmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn",
-                  },
-                  "type": Object {
-                    "S": "dag-pb",
-                  },
-                },
-              },
-            },
-          ],
           "v1-blocks-cars-position": Array [
             Object {
               "PutRequest": Object {
@@ -271,23 +192,6 @@ Object {
     "batchCreates": Array [
       Object {
         "RequestItems": Object {
-          "v1-blocks": Array [
-            Object {
-              "PutRequest": Object {
-                "Item": Object {
-                  "createdAt": Object {
-                    "S": "2022-06-24T15:15:17.401Z",
-                  },
-                  "multihash": Object {
-                    "S": "zQmPH3Su9xAqw4WRbXT6DvwNpmaXYvTKKAY2hBKJsC7j2b4",
-                  },
-                  "type": Object {
-                    "S": "unsupported",
-                  },
-                },
-              },
-            },
-          ],
           "v1-blocks-cars-position": Array [
             Object {
               "PutRequest": Object {


### PR DESCRIPTION
This PR changes `indexer-lamba` to not write to `blocks-v1` table. It also removes all the environment variables associated with it.

Main motivation can be seen at https://hackmd.io/@vasco-santos/ryjEfsGas . In this proposal, we were aiming to keep same state. However, team then decided that we can simply not write this for now and we can go back and get the type of each entry if we want to merge both tables tracking blocks in the future.